### PR TITLE
[refactor]분기 로직 및 책임 분리로 SelectingPieceState 정리

### DIFF
--- a/src/main/java/controller/GameController.java
+++ b/src/main/java/controller/GameController.java
@@ -10,7 +10,6 @@ import model.strategy.PathStrategy;
 import model.strategy.SquarePathStrategy;
 import model.yut.YutResult;
 import view.View;
-import view.swing.SwingView; // 필요 시 JavaFXView 등으로 교체 가능
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,10 +17,18 @@ import java.util.List;
 public class GameController {
 
     private Game game;
-    private View view; // 인터페이스
+    private View view;
 
     public GameController(View view) {
         this.view = view;
+    }
+
+    public Game getGame() {
+        return game;
+    }
+
+    public void setGame(Game game) {
+        this.game = game;
     }
 
     // 게임 시작 설정: 플레이어 수, 말 수, 보드 타입
@@ -50,11 +57,11 @@ public class GameController {
 
     // 윷 던지기
     public void handleYutThrow(YutResult result) {
-        // 윷 결과를 게임에 누적 (큐에 추가)
-        game.enqueueYutResult(result);
+        game.enqueueYutResult(result); // 윷 결과를 게임에 누적 (큐에 추가)
+        view.updateYutResult(result); // View에 현재 누적된 윷 결과 상태 갱신
 
-        // View에 현재 누적된 윷 결과 상태 갱신
-        view.updateYutResult(result);
+        GameMessage msg = game.getLastMessage();
+        view.updateStatus(msg.getContent(), msg.getType());
 
         // 사용자의 다음 액션(말 선택)을 기다리는 상태 유지
         view.updateStatus(game.getCurrentPlayer().getName() + " 이(가) 윷을 던졌습니다: " + result.getName() + ". 말을 선택하세요.");
@@ -68,26 +75,23 @@ public class GameController {
         // 말 이동 후 렌더링
         view.renderGame(game);
         GameMessage msg = game.getLastMessage();
-        view.updateStatus(msg.getText(), msg.getType());
+        view.updateStatus(msg.getContent(), msg.getType());
 
-        // 혹시라도 게임이 다른 이유로 종료됐을 경우
-        if (result.isGameFinished()) {
-            if (result.getWinner() != null) {
-                view.showWinner(result.getWinner());
+        if (result.gameEnded()) {
+            if (result.winner() != null) {
+                view.showWinner(result.winner());
             }
             view.promptRestart(this);
             return;
         }
 
-        if (!result.isBonusTurn()) {
+        if (!result.bonusTurn()) {
             game.nextTurn(); // 다음 플레이어로 넘어감
         }
     }
 
 
-    public Game getGame() {
-        return game;
-    }
+
 
 
 

--- a/src/main/java/model/Game.java
+++ b/src/main/java/model/Game.java
@@ -1,6 +1,5 @@
 package model;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;

--- a/src/main/java/model/dto/GameMessage.java
+++ b/src/main/java/model/dto/GameMessage.java
@@ -2,16 +2,16 @@ package model.dto;
 
 
 public class GameMessage {
-    private final String text;
+    private final String content;
     private final MessageType type;
 
-    public GameMessage(String text, MessageType type) {
-        this.text = text;
+    public GameMessage(String content, MessageType type) {
+        this.content = content;
         this.type = type;
     }
 
-    public String getText() {
-        return text;
+    public String getContent() {
+        return content;
     }
 
     public MessageType getType() {

--- a/src/main/java/model/dto/GameMessageFactory.java
+++ b/src/main/java/model/dto/GameMessageFactory.java
@@ -1,0 +1,75 @@
+package model.dto;
+
+import model.player.Player;
+
+public class GameMessageFactory {
+    private static final String NO_MOVABLE_MESSAGE_SUFFIX = "님은 이동할 수 있는 말이 없습니다.";
+    private static final String SELECT_PIECE_PROMPT_SUFFIX = "님, 이동할 말을 선택해주세요.";
+
+    private static final String ALREADY_THROWN_MESSAGE = "이미 윷을 던졌습니다. 말을 선택하세요.";
+    private static final String NO_RESULT_MESSAGE = "적용할 윷 결과가 없습니다.";
+
+    private static final String INVALID_SELECTION_MESSAGE = "잘못된 말 선택입니다.";
+    private static final String GOAL_MESSAGE_SUFFIX = "의 말이 골인했습니다!";
+
+    private static final String CAPTURE_MESSAGE_SUFFIX = "이(가) 상대 말을 잡았습니다!";
+    private static final String BONUS_TURN_SUFFIX = " 한 번 더 던지세요.";
+    private static final String MOVE_MESSAGE_SUFFIX = "이(가) 말을 이동했습니다.";
+    private static final String YUT_OR_MO_MESSAGE_SUFFIX = "이(가) 윷 또는 모로 추가 턴을 얻었습니다.";
+
+    private static final String NEXT_RESULT_SUFFIX = " 다음 결과를 적용할 말을 선택하세요.";
+    private static final String NEXT_TURN_SUFFIX = " 다음 플레이어의 차례입니다.";
+    private static final String THROW_PROMPT_SUFFIX = " 추가 턴입니다. 윷을 던지세요.";
+
+
+    public static GameMessage noMovablePieceMessage(Player player) {
+        return new GameMessage(player.getName() + NO_MOVABLE_MESSAGE_SUFFIX, MessageType.INFO);
+    }
+
+    public static GameMessage selectPiecePrompt(Player player) {
+        return new GameMessage(player.getName() + SELECT_PIECE_PROMPT_SUFFIX, MessageType.INFO);
+    }
+
+    public static GameMessage invalidSelectionMessage() {
+        return new GameMessage(INVALID_SELECTION_MESSAGE, MessageType.WARN);
+    }
+
+    public static GameMessage alreadyThrownMessage() {
+        return new GameMessage(ALREADY_THROWN_MESSAGE, MessageType.WARN);
+    }
+
+    public static GameMessage noResultMessage() {
+        return new GameMessage(NO_RESULT_MESSAGE, MessageType.WARN);
+    }
+
+
+    public static GameMessage goalMessage(String playerName) {
+        return new GameMessage(playerName + GOAL_MESSAGE_SUFFIX, MessageType.INFO);
+    }
+
+    public static GameMessage captureMessage(String playerName, boolean bonusTurn) {
+        String msg = playerName + CAPTURE_MESSAGE_SUFFIX;
+        return new GameMessage(bonusTurn ? msg + BONUS_TURN_SUFFIX : msg, MessageType.INFO);
+    }
+
+    public static GameMessage moveMessage(String playerName) {
+        return new GameMessage(playerName + MOVE_MESSAGE_SUFFIX, MessageType.INFO);
+    }
+
+    public static GameMessage yutOrMoMessage(String playerName) {
+        return new GameMessage(playerName + YUT_OR_MO_MESSAGE_SUFFIX, MessageType.INFO);
+    }
+
+
+    public static GameMessage withNextResultPrompt(GameMessage base) {
+        return new GameMessage(base.getContent() + NEXT_RESULT_SUFFIX, base.getType());
+    }
+
+    public static GameMessage withNextTurnPrompt(GameMessage base) {
+        return new GameMessage(base.getContent() + NEXT_TURN_SUFFIX, base.getType());
+    }
+
+    public static GameMessage withThrowPrompt(GameMessage base) {
+        return new GameMessage(base.getContent() + THROW_PROMPT_SUFFIX, base.getType());
+    }
+}

--- a/src/main/java/model/dto/MoveResult.java
+++ b/src/main/java/model/dto/MoveResult.java
@@ -1,27 +1,29 @@
 package model.dto;
 
+import model.Game;
 import model.player.Player;
 
-public class MoveResult {
-    private final boolean captured;
-    private final boolean gameFinished;
-    private final Player winner;
-    private final boolean bonusTurn;
-    private final boolean turnSkipped;
-
-
-    public MoveResult(boolean captured, boolean gameFinished,
-                      Player winner, boolean bonusTurn, boolean turnSkipped) {
-        this.captured = captured;
-        this.gameFinished = gameFinished;
-        this.winner = winner;
-        this.bonusTurn = bonusTurn;
-        this.turnSkipped = turnSkipped;
+public record MoveResult(
+        boolean captured,
+        boolean gameEnded,
+        Player winner,
+        boolean bonusTurn,
+        boolean turnSkipped
+) {
+    public static MoveResult fail() {
+        return new MoveResult(false, false, null, false, false);
     }
 
-    public boolean isCaptured() { return captured; }
-    public boolean isGameFinished() { return gameFinished; }
-    public Player getWinner() { return winner; }
-    public boolean isBonusTurn() { return bonusTurn; }
-    public boolean isTurnSkipped() { return turnSkipped; }
+    public static MoveResult goal(Player winner, Game game) {
+        return new MoveResult(false, game.isFinished(), winner, false, false);
+    }
+
+    public static MoveResult success(boolean captured, boolean bonusTurn, Player winner, Game game) {
+        return new MoveResult(captured, game.isFinished(), winner, bonusTurn, false);
+    }
+
+    public static MoveResult skipped() {
+        return new MoveResult(false, false, null, false, true);
+    }
+
 }

--- a/src/main/java/model/piece/PieceUtil.java
+++ b/src/main/java/model/piece/PieceUtil.java
@@ -1,5 +1,7 @@
 package model.piece;
 
+import model.Game;
+import model.board.Board;
 import model.player.Player;
 import model.strategy.PathStrategy;
 import model.yut.YutResult;
@@ -9,6 +11,20 @@ import java.util.List;
 
 public class PieceUtil {
 
+    public static List<Piece> getMovableGroup(Piece selected, Game game) {
+        List<Piece> group = new ArrayList<>();
+        for (Piece other : selected.getOwner().getPieces()) {
+            if (!other.isFinished() &&
+                    other.getPosition().equals(selected.getPosition()) &&
+                    other.hasMoved()) {
+                group.add(other);
+            }
+        }
+        group.add(selected); // 항상 자신 추가
+        ensureGroupConsistency(group);
+        return group;
+    }
+
     // 그룹 내 모든 Piece가 동일한 참조를 갖도록 설정
     public static void ensureGroupConsistency(List<Piece> group) {
         for (Piece p : group) {
@@ -17,8 +33,16 @@ public class PieceUtil {
     }
 
     // 단독 그룹으로 리셋 (잡힘, 완주)
-    public static void resetGroupToSelf(Piece p) {
-        p.setGroup(List.of(p));
+    public static void resetGroupToSelf(Piece piece) {
+        List<Piece> selfGroup = new ArrayList<>();
+        selfGroup.add(piece);
+        piece.setGroup(selfGroup);
+    }
+
+    public static boolean allFinished(List<Piece> group, Board board) {
+        return group.stream().allMatch(p ->
+                p.getPosition().equals(board.getPathStrategy().getPath().get(board.getPathStrategy().getPath().size() - 1))
+        );
     }
 
     public static void initializePath(Piece piece, PathStrategy strategy) {
@@ -52,4 +76,6 @@ public class PieceUtil {
             return newIndex >= 0; // 빽도일 경우 되돌릴 수 있는지
         }
     }
+
+
 }

--- a/src/main/java/model/state/SelectingPieceState.java
+++ b/src/main/java/model/state/SelectingPieceState.java
@@ -3,11 +3,13 @@ package model.state;
 import model.Game;
 import model.board.Board;
 import model.dto.GameMessage;
+import model.dto.GameMessageFactory;
 import model.dto.MessageType;
 import model.dto.MoveResult;
 import model.piece.Piece;
 import model.piece.PieceUtil;
 import model.position.Position;
+import model.yut.YutQueueHandler;
 import model.yut.YutResult;
 
 import java.util.ArrayList;
@@ -19,94 +21,71 @@ public class SelectingPieceState implements GameState {
 
     public SelectingPieceState(Game game, YutResult result) {
         this.game = game;
-
+        this.game.enqueueYutResult(result);
     }
 
     @Override
     public MoveResult handleYutThrowWithResult(YutResult result) {
-        game.setLastMessage(new GameMessage("이미 윷을 던졌습니다. 말을 선택하세요.", MessageType.WARN));
-
-        return new MoveResult(
-                false,   // captured
-                game.isFinished(),
-                null,    // winner
-                false,   // bonusTurn
-                false    // turnSkipped
-        );
+        game.setLastMessage(GameMessageFactory.alreadyThrownMessage());
+        return MoveResult.fail();
     }
 
     @Override
     public MoveResult handlePieceSelectWithResult(Piece piece) {
         if (piece.isFinished() || piece.getOwner() != game.getCurrentPlayer()) {
-            game.setLastMessage(new GameMessage("잘못된 말 선택입니다.", MessageType.WARN));
-            return new MoveResult(false, false, null, false, false);
+            game.setLastMessage(GameMessageFactory.invalidSelectionMessage());
+            return MoveResult.fail();
         }
 
-        YutResult moveResult = game.dequeueYutResult();
+        YutResult moveResult = YutQueueHandler.dequeueResult(game);
         if (moveResult == null) {
-            game.setLastMessage(new GameMessage("적용할 윷 결과가 없습니다.", MessageType.WARN));
-            return new MoveResult( false, false, null, false, false);
+            game.setLastMessage(GameMessageFactory.noResultMessage());
+            return MoveResult.fail();
         }
 
         // 그룹 설정
-        List<Piece> group = new ArrayList<>();
-        group.add(piece);
-        for (Piece other : piece.getOwner().getPieces()) {
-            if (other != piece &&
-                    !other.isFinished() &&
-                    other.getPosition().equals(piece.getPosition()) &&
-                    other.hasMoved()) {
-                group.add(other);
-            }
-        }
-        PieceUtil.ensureGroupConsistency(group);
+        List<Piece> group = PieceUtil.getMovableGroup(piece, game);
 
         // 이동 처리
-        Board board = game.getBoard();
-        boolean captured = board.movePiece(piece, moveResult, game.getPlayers());
+        boolean captured = game.getBoard().movePiece(piece, moveResult, game.getPlayers());
 
-        Position finalPos = board.getPathStrategy().getPath().get(
-                board.getPathStrategy().getPath().size() - 1);
-
-        boolean allAtGoal = group.stream().allMatch(p -> p.getPosition().equals(finalPos));
-        if (allAtGoal) {
+        String playerName = piece.getOwner().getName();
+        if (PieceUtil.allFinished(group, game.getBoard())) {
             for (Piece p : group) {
                 p.setFinished(true);
                 PieceUtil.resetGroupToSelf(p);
             }
-
-            game.setLastMessage(new GameMessage(piece.getOwner().getName() + "의 말이 골인했습니다!", MessageType.INFO));
-            return new MoveResult(
-                    false, game.checkAndHandleWinner(), game.isFinished() ? piece.getOwner() : null, false, false);
+            game.setLastMessage(GameMessageFactory.goalMessage(playerName));
+            return MoveResult.goal(piece.getOwner(), game);
         }
 
         // 추가 턴 조건
         boolean isYutOrMo = moveResult == YutResult.YUT || moveResult == YutResult.MO;
         boolean bonusTurn = (captured && !isYutOrMo) || (isYutOrMo && !captured);
 
-        String message;
-        if (captured) {
-            message = piece.getOwner().getName() + "이(가) 상대 말을 잡았습니다!" + (bonusTurn ? " 한 번 더 던지세요." : "");
-        } else if (isYutOrMo) {
-            message = piece.getOwner().getName() + "이(가) 윷 또는 모로 추가 턴을 얻었습니다.";
-        } else {
-            message = piece.getOwner().getName() + "이(가) 말을 이동했습니다.";
-        }
+        // 기본 메시지 결정
+        GameMessage baseMessage = captured
+                ? GameMessageFactory.captureMessage(playerName, bonusTurn)
+                : isYutOrMo
+                ? GameMessageFactory.yutOrMoMessage(playerName)
+                : GameMessageFactory.moveMessage(playerName);
 
         // 다음 상태 결정
         if (game.hasPendingYutResults()) {
-            // 아직 큐에 결과 남아 있음 → SelectingPieceState 유지
-            game.setLastMessage(new GameMessage(message + " 다음 결과를 적용할 말을 선택하세요.", MessageType.INFO));
-            return new MoveResult(captured, game.checkAndHandleWinner(), game.isFinished() ? piece.getOwner() : null, false, false);
-        } else if (bonusTurn) {
-            game.setState(new WaitingForThrowState(game));
-            game.setLastMessage(new GameMessage(message + " 추가 턴입니다. 윷을 던지세요.", MessageType.INFO));
-            return new MoveResult(captured, game.checkAndHandleWinner(), game.isFinished() ? piece.getOwner() : null, true, false);
-        } else {
-            game.nextTurn();
-            game.setLastMessage(new GameMessage(message + " 다음 플레이어의 차례입니다.", MessageType.INFO));
-            return new MoveResult(captured, game.checkAndHandleWinner(), game.isFinished() ? piece.getOwner() : null, false, false);
+            game.setLastMessage(GameMessageFactory.withNextResultPrompt(baseMessage));
+            return MoveResult.success(captured, false, game.isFinished() ? piece.getOwner() : null, game);
         }
+
+        if (bonusTurn) {
+            game.setState(new WaitingForThrowState(game));
+            game.setLastMessage(GameMessageFactory.withThrowPrompt(baseMessage));
+            return MoveResult.success(captured, true, game.isFinished() ? piece.getOwner() : null, game);
+        }
+
+        // 턴 종료
+        game.nextTurn();
+        game.setLastMessage(GameMessageFactory.withNextTurnPrompt(baseMessage));
+        return MoveResult.success(captured, false, game.isFinished() ? piece.getOwner() : null, game);
     }
 
 }

--- a/src/main/java/model/yut/YutQueueHandler.java
+++ b/src/main/java/model/yut/YutQueueHandler.java
@@ -1,0 +1,25 @@
+package model.yut;
+
+import model.Game;
+import model.dto.GameMessage;
+import model.dto.MessageType;
+
+import java.util.Queue;
+
+public class YutQueueHandler {
+    public static YutResult pollNextYutResult(Queue<YutResult> queue) {
+        return queue.isEmpty() ? null : queue.poll();
+    }
+
+    public static boolean hasPendingMoves(Queue<YutResult> queue) {
+        return !queue.isEmpty();
+    }
+
+    public static YutResult dequeueResult(Game game) {
+        YutResult result = game.dequeueYutResult();
+        if (result == null) {
+            game.setLastMessage(new GameMessage("적용할 윷 결과가 없습니다.", MessageType.WARN));
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
- YutResult 큐 처리 로직을 YutQueueHandler로 분리
- 말 그룹 구성 및 이동 가능한 그룹 추출 로직을 PieceUtil로 위임
- 메시지 생성 로직을 GameMessageFactory로 통합
- SelectingPieceState는 게임 상태 전이 중심 로직에 집중하도록 리팩토링
- GameState 인터페이스는 불필요한 상태 진입 메서드를 제거해 단순화