### PR TITLE
내가 메인 버그 잡았다고

### DIFF
--- a/src/main/java/model/player/Player.java
+++ b/src/main/java/model/player/Player.java
@@ -42,7 +42,7 @@ public class Player {
                             /* x */ baseX,
                             /* y */ BASE_Y_OFFSET + (i - 1) * PIECE_SPACING_Y
                     );
-                    return new Piece(this, i, startPos);
+                    return new Piece(this, this.id * pieceCount + i, startPos);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
[fix turn main bug] #37 onSelectPieceById가 다른 플레이어 턴에서도 항상 Player1의 말만 findFirst하던 문제를 각 piece마다 고유 id 부여하는 걸로 해결